### PR TITLE
fix: Ensure "Register User" tab content is visible

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -99,6 +99,7 @@
             <input id="tab3" type="radio" name="tabs">
             <input id="tab4" type="radio" name="tabs">
             <input id="tab5" type="radio" name="tabs">
+            <input id="tab6" type="radio" name="tabs">
             
             <div class="tab-header">
                 <label for="tab1">👥 Accounts</label>
@@ -106,6 +107,7 @@
                 <label for="tab3">📦 Items</label>
                 <label for="tab4">🙋 Volunteers</label>
                 <label for="tab5">🎵 Music</label>
+                <label for="tab6">➕ Register User</label>
             </div>
 
             <div class="content tab-content" id="content1">
@@ -231,6 +233,28 @@
                     </thead>
                     <tbody id="musicTable"></tbody>
                 </table>
+            </div>
+
+            <div class="content tab-content" id="content6"><h3>User Registration</h3>
+                <form id="registerUserForm">
+                    <div class="form-group">
+                        <label for="registerName">Name</label>
+                        <input type="text" id="registerName" placeholder="Enter name" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerEmail">Email</label>
+                        <input type="email" id="registerEmail" placeholder="Enter email" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerPassword">Password</label>
+                        <input type="password" id="registerPassword" placeholder="Enter password" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="registerRole">Role (Optional)</label>
+                        <input type="text" id="registerRole" placeholder="Enter role (e.g., admin)">
+                    </div>
+                    <button type="submit" class="btn btn-primary" id="registerUserBtn">Register User</button>
+                </form>
             </div>
         </div>
     </div>

--- a/css/admin.css
+++ b/css/admin.css
@@ -406,7 +406,8 @@ tr:nth-child(even) {
 .enhanced-tabs input[type="radio"]:nth-of-type(2):checked ~ #content2,
 .enhanced-tabs input[type="radio"]:nth-of-type(3):checked ~ #content3,
 .enhanced-tabs input[type="radio"]:nth-of-type(4):checked ~ #content4,
-.enhanced-tabs input[type="radio"]:nth-of-type(5):checked ~ #content5 {
+.enhanced-tabs input[type="radio"]:nth-of-type(5):checked ~ #content5,
+.enhanced-tabs input[type="radio"]:nth-of-type(6):checked ~ #content6 { /* Added this line */
     display: block;
 }
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -85,6 +85,75 @@ class PoolpartyAdmin {
         }
     }
 
+    // ➕ Register User
+    async registerUser() {
+        const nameInput = document.getElementById('registerName');
+        const emailInput = document.getElementById('registerEmail');
+        const passwordInput = document.getElementById('registerPassword');
+        const roleInput = document.getElementById('registerRole');
+
+        const nameValue = nameInput.value.trim();
+        const emailValue = emailInput.value.trim();
+        const passwordValue = passwordInput.value.trim();
+        const roleValue = roleInput.value.trim();
+
+        // Basic validation
+        if (!nameValue || !emailValue || !passwordValue) {
+            this.showNotification('Name, Email, and Password are required.', 'error');
+            return;
+        }
+        if (!emailValue.includes('@') || !emailValue.includes('.')) {
+            this.showNotification('Please enter a valid email address.', 'error');
+            return;
+        }
+        if (passwordValue.length < 8) {
+            this.showNotification('Password must be at least 8 characters long.', 'error');
+            return;
+        }
+
+        const userData = {
+            name: nameValue,
+            email: emailValue,
+            password: passwordValue,
+        };
+        if (roleValue) {
+            userData.role = roleValue;
+        }
+
+        try {
+            await this.apiCall('admin/register', {
+                method: 'POST',
+                body: JSON.stringify(userData)
+            });
+            this.showNotification('User registered successfully!', 'success');
+            
+            // Reset the form
+            const registerForm = document.getElementById('registerUserForm');
+            if (registerForm) {
+                registerForm.reset();
+            }
+
+            // Switch to accounts tab
+            const accountsTabRadio = document.getElementById('tab1');
+            if (accountsTabRadio) {
+                accountsTabRadio.checked = true;
+                // Dispatch a change event to trigger tab switching logic
+                const changeEvent = new Event('change', { bubbles: true });
+                accountsTabRadio.dispatchEvent(changeEvent);
+            }
+
+            // Refresh all data, which will re-render tables including the new account
+            await this.loadAllData();
+            // The tab switching logic and loadAllData should handle re-rendering.
+            // If needed, one could force it:
+            // this.state.currentTab = 'account';
+            // this.renderTable('account');
+
+        } catch (error) {
+            this.showNotification(error.message || 'Failed to register user.', 'error');
+        }
+    }
+
     // 📊 Data Loading
     async loadAllData() {
         console.log('📊 Loading all data...');
@@ -165,6 +234,12 @@ class PoolpartyAdmin {
     }
 
     renderTable(section) {
+        if (section === 'register') {
+            console.log(`🎯 Section is 'register', skipping table rendering.`);
+            // Ensure loading states are handled if they were set for 'register'
+            this.setLoading('register', false); 
+            return;
+        }
         console.log(`🎯 Rendering table for section: ${section}`);
         
         const { data } = this.state;
@@ -624,14 +699,32 @@ class PoolpartyAdmin {
         } else {
             this.state.loading.delete(section);
         }
+
+        let loadingEl;
+        let containerEl;
+
+        if (section === 'register') {
+            loadingEl = document.getElementById('registerLoading'); // Might be null
+            containerEl = document.getElementById('content6');
+            console.log(`🔄 Loading state for 'register' (static tab): ${isLoading}`);
+        } else {
+            loadingEl = document.getElementById(`${section}Loading`);
+            containerEl = document.getElementById(`${section}TableContainer`);
+            console.log(`🔄 Loading state for ${section}: ${isLoading}`);
+        }
         
-        const loadingEl = document.getElementById(`${section}Loading`);
-        const containerEl = document.getElementById(`${section}TableContainer`);
-        
-        if (loadingEl) loadingEl.style.display = isLoading ? 'block' : 'none';
-        if (containerEl) containerEl.style.display = isLoading ? 'none' : 'table';
-        
-        console.log(`🔄 Loading state for ${section}: ${isLoading}`);
+        if (loadingEl) {
+            loadingEl.style.display = isLoading ? 'block' : 'none';
+        }
+        // For 'register' section, containerEl is 'content6' (a div)
+        // For other sections, containerEl is a 'table'
+        if (containerEl) {
+            if (section === 'register') {
+                containerEl.style.display = isLoading ? 'none' : 'block';
+            } else {
+                containerEl.style.display = isLoading ? 'none' : 'table';
+            }
+        }
     }
 
     // 🔔 Notifications
@@ -684,17 +777,42 @@ class PoolpartyAdmin {
         document.querySelectorAll('input[name="tabs"]').forEach(tab => {
             tab.addEventListener('change', (e) => {
                 if (e.target.checked) {
-                    const sections = ['account', 'registration', 'item', 'volunteer', 'music'];
-                    const section = sections[parseInt(e.target.id.replace('tab', '')) - 1];
-                    this.state.currentTab = section;
-                    
-                    console.log(`🔄 Switching to tab: ${section}`);
-                    
-                    // Re-render the selected table
-                    setTimeout(() => {
-                        this.renderTable(section);
-                        console.log(`✅ ${section} tab rendered`);
-                    }, 100);
+                    const sections = ['account', 'registration', 'item', 'volunteer', 'music', 'register'];
+                    const tabIndex = parseInt(e.target.id.replace('tab', '')) - 1;
+
+                    if (tabIndex < sections.length) {
+                        const section = sections[tabIndex];
+                        this.state.currentTab = section;
+                        console.log(`🔄 Switching to tab: ${section}`);
+
+                        // Hide all tab content first
+                        document.querySelectorAll('.tab-content').forEach(tc => tc.style.display = 'none');
+
+                        setTimeout(() => {
+                            if (section !== 'register') {
+                                // Show the specific content div for table-based sections before rendering table
+                                const currentContentDiv = document.getElementById(`content${tabIndex + 1}`);
+                                if (currentContentDiv) {
+                                    currentContentDiv.style.display = 'block';
+                                }
+                                this.renderTable(section); // renderTable calls setLoading internally
+                                console.log(`✅ ${section} tab rendered`);
+                            } else {
+                                // For 'register' tab, content is static. Explicitly show its content.
+                                const registerContentDiv = document.getElementById('content6');
+                                if (registerContentDiv) {
+                                    registerContentDiv.style.display = 'block';
+                                }
+                                console.log(`✅ 'register' tab is static, content displayed.`);
+                                // Ensure loading states for other sections are cleared
+                                Object.keys(this.dataMapping).forEach(key => this.setLoading(key, false));
+                                this.setLoading('music', false); 
+                                this.setLoading('register', false); // Clear any loading state for register tab itself
+                            }
+                        }, 100);
+                    } else {
+                        console.warn(`⚠️ Tab index ${tabIndex} out of bounds for sections array.`);
+                    }
                 }
             });
         });
@@ -723,6 +841,15 @@ class PoolpartyAdmin {
         if (deleteAllVolunteersBtn) {
             deleteAllVolunteersBtn.addEventListener('click', () => {
                 this.showBulkDeleteConfirm('volunteer');
+            });
+        }
+
+        // User Registration form
+        const registerUserForm = document.getElementById('registerUserForm');
+        if (registerUserForm) {
+            registerUserForm.addEventListener('submit', (event) => {
+                event.preventDefault();
+                this.registerUser();
             });
         }
     }


### PR DESCRIPTION
Addresses an issue where the content of the "Register User" tab in the admin panel was not being displayed when the tab was selected.

The fix includes:
- Adding a CSS rule to `css/admin.css` to set `display: block` on `#content6` when `#tab6` is checked.
- Ensuring JavaScript logic in `js/admin.js` (`setupEventListeners` and `setLoading`) correctly handles the display of `#content6` and does not interfere with its visibility when the 'register' tab is active.

The tab content should now be consistently visible when selected.